### PR TITLE
Dev/windows/fix_bugs

### DIFF
--- a/bvhview.c
+++ b/bvhview.c
@@ -1152,7 +1152,7 @@ static bool BVHDataLoad(BVHData* bvh, const char* filename, char* errMsg, int er
 {
     // Read file Contents
 
-    FILE* f = fopen(filename, "r");
+    FILE* f = fopen(filename, "rb");
 
     if (f == NULL)
     {

--- a/bvhview.c
+++ b/bvhview.c
@@ -3866,7 +3866,7 @@ static void ApplicationUpdate(void* voidApplicationState)
 
         if (app->scrubberSettings.playTime >= app->scrubberSettings.timeMax)
         {
-            app->scrubberSettings.playTime = app->scrubberSettings.looping ?
+            app->scrubberSettings.playTime = (app->scrubberSettings.looping && app->scrubberSettings.timeMax >= 1e-8f) ?
                 fmod(app->scrubberSettings.playTime, app->scrubberSettings.timeMax) + app->scrubberSettings.timeMin :
                 app->scrubberSettings.timeMax;
         }


### PR DESCRIPTION
Bugfix:
- `fmod` gives `nan` when scrubberSettings.timeMax is 0.0f, if scrubberSettings.looping is initialized as true;  
- use binary-read s.t. `fseek` get correct buffer length.  