### PR TITLE
Add macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Download this repo and run `make` in the main directory to build `bvhview.exe`.
 
 To build a release version with optimizations enabled and no console window run `make BUILD_MODE=RELEASE` in the main directory instead.
 
+## macOS
+
+Install the Xcode command line tools (or an alternative toolchain such as Homebrew’s GCC/Clang) so `make` and `clang` are available.
+
+Download [raylib](https://github.com/raysan5/raylib) into `~/raylib/raylib`.
+
+Download [raygui](https://github.com/raysan5/raygui) into `~/raylib/raygui`.
+
+Build raylib by going to `~/raylib/raylib/src` and running `make PLATFORM=PLATFORM_DESKTOP`.
+
+Download this repo and run `make PLATFORM_OS=Darwin` in the main directory to build `bvhview`.
+
+To build a release version with optimizations enabled run `make BUILD_MODE=RELEASE PLATFORM_OS=Darwin` in the main directory instead.
+
 ## Linux
 
 Download [raylib](https://github.com/raysan5/raylib) into `~/raylib/raylib`.

--- a/bvhview.c
+++ b/bvhview.c
@@ -2586,21 +2586,39 @@ static inline void CapsuleDataUpdateForCharacters(CapsuleData* capsuleData, Char
 #define AO_CAPSULES_MAX 32
 #define SHADOW_CAPSULES_MAX 64
 
+
 #define GLSL_DEFINE_VALUE(X) #X
 #define GLSL_DEFINE(X) "#define " #X " " GLSL_DEFINE_VALUE(X) " \n"
-#define GLSL(X) \
-  "#version 300 es\n" \
+
+#if defined(PLATFORM_WEB)
+#define GLSL_VERSION "#version 300 es\n"
+#define GLSL_PRECISION "precision highp float;\nprecision mediump int;\n"
+#else
+#define GLSL_VERSION "#version 330 core\n"
+#define GLSL_PRECISION ""
+#endif
+
+#define GLSL_STRINGIFY_INNER(X) #X
+#define GLSL_STRINGIFY(X) GLSL_STRINGIFY_INNER(X)
+
+#define GLSL_HEADER \
+  GLSL_VERSION \
   GLSL_DEFINE(AO_RATIO_MAX) \
   GLSL_DEFINE(AO_CAPSULES_MAX) \
   GLSL_DEFINE(SHADOW_CAPSULES_MAX) \
-  GLSL_DEFINE(PI) \
-  #X
+  GLSL_DEFINE(PI)
+
+#define GLSL_SHADER(X) \
+  GLSL_HEADER \
+  GLSL_STRINGIFY(X)
+
+#define GLSL_SHADER_WITH_PRECISION(X) \
+  GLSL_HEADER \
+  GLSL_PRECISION \
+  GLSL_STRINGIFY(X)
 
 // Vertex Shader
-static const char* shaderVS = GLSL(
-
-precision highp float;
-precision mediump int;
+static const char* shaderVS = GLSL_SHADER(
 
 in vec3 vertexPosition;
 in vec2 vertexTexCoord;
@@ -2659,10 +2677,7 @@ void main()
 );
 
 // Fragment Shader
-static const char* shaderFS = GLSL(
-
-precision highp float;
-precision mediump int;
+static const char* shaderFS = GLSL_SHADER_WITH_PRECISION(
 
 in vec3 fragPosition;
 in vec2 fragTexCoord;


### PR DESCRIPTION
Hi @orangeduck, thanks for publishing this great project! 

I fiddled a bit with building BVHView for macOS and succeeded with a few modifications to `GLSL`-related macros. 

I am not familiar with C and got a ton of help from LLMs, so I would appreciate a thorough review!

---

Here are the errors I saw before the edits:

**From terminal**:

```bash 
~/G/BVHView  feat/macos-build  ./bvhview
INFO: Initializing raylib 5.6-dev
INFO: Platform backend: DESKTOP (GLFW)
INFO: Supported raylib modules:
INFO:     > rcore:..... loaded (mandatory)
INFO:     > rlgl:...... loaded (mandatory)
INFO:     > rshapes:... loaded (optional)
INFO:     > rtextures:. loaded (optional)
INFO:     > rtext:..... loaded (optional)
INFO:     > rmodels:... loaded (optional)
INFO:     > raudio:.... loaded (optional)
INFO: DISPLAY: Trying to enable MSAA x4
INFO: DISPLAY: Trying to enable VSYNC
INFO: DISPLAY: Device initialized successfully
INFO:     > Display size: 1728 x 1117
INFO:     > Screen size:  1280 x 720
INFO:     > Render size:  1280 x 720
INFO:     > Viewport offsets: 0, 0
INFO: GLAD: OpenGL extensions loaded successfully
INFO: GL: Supported extensions count: 43
INFO: GL: OpenGL device information:
INFO:     > Vendor:   Apple
INFO:     > Renderer: Apple M1 Pro
INFO:     > Version:  4.1 Metal - 89.4
INFO:     > GLSL:     4.10
INFO: GL: VAO extension detected, VAO functions loaded successfully
INFO: GL: NPOT textures extension detected, full NPOT textures supported
INFO: GL: DXT compressed textures supported
INFO: PLATFORM: DESKTOP (GLFW - Cocoa): Initialized successfully
INFO: TEXTURE: [ID 1] Texture loaded successfully (1x1 | R8G8B8A8 | 1 mipmaps)
INFO: TEXTURE: [ID 1] Default texture loaded successfully
INFO: SHADER: [ID 1] Vertex shader compiled successfully
INFO: SHADER: [ID 2] Fragment shader compiled successfully
INFO: SHADER: [ID 3] Program shader loaded successfully
INFO: SHADER: [ID 3] Default shader loaded successfully
INFO: RLGL: Render batch vertex buffers loaded successfully in RAM (CPU)
INFO: RLGL: Render batch vertex buffers loaded successfully in VRAM (GPU)
INFO: RLGL: Default OpenGL state initialized successfully
INFO: TEXTURE: [ID 2] Texture loaded successfully (128x128 | GRAY_ALPHA | 1 mipmaps)
INFO: FONT: Default font loaded successfully (224 glyphs)
INFO: SYSTEM: Working Directory: /Users/yunhocho/GitHub/BVHView
INFO: TIMER: Target time per frame: 16.667 milliseconds
WARNING: SHADER: [ID 4] Failed to compile vertex shader code
WARNING: SHADER: [ID 4] Compile error: ERROR: 0:6: 'GLSL_PRECISION' : syntax error: syntax error

WARNING: SHADER: [ID 4] Failed to compile fragment shader code
WARNING: SHADER: [ID 4] Compile error: ERROR: 0:6: 'GLSL_PRECISION' : syntax error: syntax error

INFO: VAO: [ID 2] Mesh uploaded successfully to VRAM (GPU)
INFO: VAO: [ID 3] Mesh uploaded successfully to VRAM (GPU)
INFO: TEXTURE: [ID 3] Texture loaded successfully (32x32 | GRAYSCALE | 1 mipmaps)
INFO: TEXTURE: [ID 4] Texture loaded successfully (256x128 | GRAYSCALE | 1 mipmaps)
fish: Job 1, './bvhview' terminated by signal SIGSEGV (Address boundary error)
```

**From macOS crash reporter**:

```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               bvhview [64436]
Path:                  /Users/USER/*/bvhview
Identifier:            bvhview
Version:               ???
Code Type:             ARM-64 (Native)
Parent Process:        fish [40243]
Responsible:           Electron [38996]
User ID:               501

Date/Time:             2025-11-08 14:24:57.7275 -0500
OS Version:            macOS 15.6 (24G84)
Report Version:        12
Anonymous UUID:        F28DFB10-4B8E-C55A-67BA-BEA2DAB74AA9

Sleep/Wake UUID:       9A59E00D-9823-46D2-81D6-D15DB613D53B

Time Awake Since Boot: 16000 seconds
Time Since Wake:       96 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000030
Exception Codes:       0x0000000000000001, 0x0000000000000030

Termination Reason:    Namespace SIGNAL, Code 11 Segmentation fault: 11
Terminating Process:   exc handler [64436]

VM Region Info: 0x30 is not in any region.  Bytes before following region: 4308959184
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      __TEXT                      100d58000-100e6c000    [ 1104K] r-x/r-x SM=COW  bvhview

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   bvhview                       	       0x100e179a0 DrawMesh + 84
1   bvhview                       	       0x100e1799c DrawMesh + 80
2   bvhview                       	       0x100e1fdc8 DrawModelEx + 1228
3   bvhview                       	       0x100e1f8f0 DrawModel + 92
4   bvhview                       	       0x100d72bd4 ApplicationUpdate + 5140 (bvhview.c:4107)
5   bvhview                       	       0x100d6f140 main + 960 (bvhview.c:4470)
6   dyld                          	       0x18e9c2b98 start + 6076

Thread 1:
0   libsystem_pthread.dylib       	       0x18ed5eb6c start_wqthread + 0

Thread 2:
0   libsystem_pthread.dylib       	       0x18ed5eb6c start_wqthread + 0

Thread 3:
0   libsystem_pthread.dylib       	       0x18ed5eb6c start_wqthread + 0

Thread 4:: com.apple.NSEventThread
0   libsystem_kernel.dylib        	       0x18ed21c34 mach_msg2_trap + 8
1   libsystem_kernel.dylib        	       0x18ed343a0 mach_msg2_internal + 76
2   libsystem_kernel.dylib        	       0x18ed2a764 mach_msg_overwrite + 484
3   libsystem_kernel.dylib        	       0x18ed21fa8 mach_msg + 24
4   CoreFoundation                	       0x18ee4ecbc __CFRunLoopServiceMachPort + 160
5   CoreFoundation                	       0x18ee4d5d8 __CFRunLoopRun + 1208
6   CoreFoundation                	       0x18ee4ca98 CFRunLoopRunSpecific + 572
7   AppKit                        	       0x192e9578c _NSEventThread + 140
8   libsystem_pthread.dylib       	       0x18ed63c0c _pthread_start + 136
9   libsystem_pthread.dylib       	       0x18ed5eb80 thread_start + 8

Thread 5:
0   libsystem_pthread.dylib       	       0x18ed5eb6c start_wqthread + 0


Thread 0 crashed with ARM Thread State (64-bit):
    x0: 0x000000013f06f554   x1: 0x0000000000000103   x2: 0x0000000000000103   x3: 0x0000000000000103
    x4: 0x0000000000002208   x5: 0x0000000000000018   x6: 0x0000000000000000   x7: 0x0000000000000000
    x8: 0x0000000000000000   x9: 0x0000000000000000  x10: 0x0000000000000000  x11: 0x00000000000000ff
   x12: 0x000000ff0000fd02  x13: 0x000000013f5391e0  x14: 0x01000001fd232941  x15: 0x00000001fd232940
   x16: 0x000000018ed9a884  x17: 0x00000001fdd4f7a8  x18: 0x0000000000000000  x19: 0x000000016f0a1340
   x20: 0x000000016f0a1370  x21: 0x000000016f0a1300  x22: 0x0000000000000000  x23: 0x00000000000000ff
   x24: 0x00000000000000ff  x25: 0x00000000000000ff  x26: 0x0000000000000028  x27: 0x0000000000000000
   x28: 0x0000000001010102   fp: 0x000000016f0a12d0   lr: 0x0000000100e1799c
    sp: 0x000000016f0a0fe0   pc: 0x0000000100e179a0 cpsr: 0x60001000
   far: 0x0000000000000030  esr: 0x92000006 (Data Abort) byte read Translation fault

Binary Images:
       0x100d58000 -        0x100e6bfff bvhview (*) <b3122b4a-d1f9-3b2b-8244-b53945d04198> */bvhview
       0x1016f0000 -        0x1016fbfff libobjc-trampolines.dylib (*) <a3faee04-0f8b-3428-9497-560c97eca6fb> /usr/lib/libobjc-trampolines.dylib
       0x114524000 -        0x114bbbfff com.apple.AGXMetalG13X (329.2) <6b497f3b-6583-398c-9d05-5f30a1c1bae5> /System/Library/Extensions/AGXMetalG13X.bundle/Contents/MacOS/AGXMetalG13X
       0x101758000 -        0x1017bffff com.apple.AppleMetalOpenGLRenderer (1.0) <28cfca54-b985-318a-a54a-7709dcd5f39e> /System/Library/Extensions/AppleMetalOpenGLRenderer.bundle/Contents/MacOS/AppleMetalOpenGLRenderer
       0x18e9bc000 -        0x18ea57577 dyld (*) <3247e185-ced2-36ff-9e29-47a77c23e004> /usr/lib/dyld
               0x0 - 0xffffffffffffffff ??? (*) <00000000-0000-0000-0000-000000000000> ???
       0x18ed9a000 -        0x18eda1e0b libsystem_platform.dylib (*) <fd19a599-8750-31f9-924f-c2810c938371> /usr/lib/system/libsystem_platform.dylib
       0x18ed5d000 -        0x18ed69a47 libsystem_pthread.dylib (*) <d6494ba9-171e-39fc-b1aa-28ecf87975d1> /usr/lib/system/libsystem_pthread.dylib
       0x18ed21000 -        0x18ed5c653 libsystem_kernel.dylib (*) <6e4a96ad-04b8-3e8a-b91d-087e62306246> /usr/lib/system/libsystem_kernel.dylib
       0x18edd2000 -        0x18f310fff com.apple.CoreFoundation (6.9) <8d45baee-6cc0-3b89-93fd-ea1c8e15c6d7> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
       0x192d37000 -        0x1941c7e3f com.apple.AppKit (6.9) <860c164c-d04c-30ff-8c6f-e672b74caf11> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0


-----------
Full Report
-----------

{"app_name":"bvhview","timestamp":"2025-11-08 14:24:58.00 -0500","app_version":"","slice_uuid":"b3122b4a-d1f9-3b2b-8244-b53945d04198","build_version":"","platform":1,"share_with_app_devs":1,"is_first_party":1,"bug_type":"309","os_version":"macOS 15.6 (24G84)","roots_installed":0,"incident_id":"30624D20-F25C-45E2-A012-52FF5E77F517","name":"bvhview"}
{
  "uptime" : 16000,
  "procRole" : "Foreground",
  "version" : 2,
  "userID" : 501,
  "deployVersion" : 210,
  "modelCode" : "MacBookPro18,1",
  "coalitionID" : 1260,
  "osVersion" : {
    "train" : "macOS 15.6",
    "build" : "24G84",
    "releaseType" : "User"
  },
  "captureTime" : "2025-11-08 14:24:57.7275 -0500",
  "codeSigningMonitor" : 1,
  "incident" : "30624D20-F25C-45E2-A012-52FF5E77F517",
  "pid" : 64436,
  "translated" : false,
  "cpuType" : "ARM-64",
  "roots_installed" : 0,
  "bug_type" : "309",
  "procLaunch" : "2025-11-08 14:24:57.2204 -0500",
  "procStartAbsTime" : 387401573136,
  "procExitAbsTime" : 387412697004,
  "procName" : "bvhview",
  "procPath" : "\/Users\/USER\/*\/bvhview",
  "parentProc" : "fish",
  "parentPid" : 40243,
  "coalitionName" : "com.microsoft.VSCode",
  "crashReporterKey" : "F28DFB10-4B8E-C55A-67BA-BEA2DAB74AA9",
  "lowPowerMode" : 1,
  "appleIntelligenceStatus" : {"reasons":["notOptedIn","assetIsNotReady","siriAssetIsNotReady"],"state":"unavailable"},
  "responsiblePid" : 38996,
  "responsibleProc" : "Electron",
  "codeSigningID" : "bvhview",
  "codeSigningTeamID" : "",
  "codeSigningFlags" : 570556929,
  "codeSigningValidationCategory" : 10,
  "codeSigningTrustLevel" : 4294967295,
  "codeSigningAuxiliaryInfo" : 0,
  "instructionByteStream" : {"beforePC":"9QMCqvMDAar0AwCqqAIAsAgFQvkIAUD5qIMX+CAAQLkYz\/2XaAZA+Q==","atPC":"ADFAuR8EADHAAgBUaApA+QBRQD0A2CF+6W+oUiEBJx4AGCEeAlVAPQ=="},
  "bootSessionUUID" : "35BB1F37-155D-4EB2-A5C1-1B736B7D3C50",
  "wakeTime" : 96,
  "sleepWakeUUID" : "9A59E00D-9823-46D2-81D6-D15DB613D53B",
  "sip" : "enabled",
  "vmRegionInfo" : "0x30 is not in any region.  Bytes before following region: 4308959184\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      UNUSED SPACE AT START\n--->  \n      __TEXT                      100d58000-100e6c000    [ 1104K] r-x\/r-x SM=COW  bvhview",
  "exception" : {"codes":"0x0000000000000001, 0x0000000000000030","rawCodes":[1,48],"type":"EXC_BAD_ACCESS","signal":"SIGSEGV","subtype":"KERN_INVALID_ADDRESS at 0x0000000000000030"},
  "termination" : {"flags":0,"code":11,"namespace":"SIGNAL","indicator":"Segmentation fault: 11","byProc":"exc handler","byPid":64436},
  "vmregioninfo" : "0x30 is not in any region.  Bytes before following region: 4308959184\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      UNUSED SPACE AT START\n--->  \n      __TEXT                      100d58000-100e6c000    [ 1104K] r-x\/r-x SM=COW  bvhview",
  "extMods" : {"caller":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"system":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"targeted":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"warnings":0},
  "faultingThread" : 0,
  "threads" : [{"triggered":true,"id":2191913,"threadState":{"x":[{"value":5352387924},{"value":259},{"value":259},{"value":259},{"value":8712},{"value":24},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":255},{"value":1095216725250},{"value":5357408736},{"value":72057602579835201,"symbolLocation":72057594037927937,"symbol":"OBJC_CLASS_$_MTLTextureDescriptorInternal"},{"value":8541907264,"symbolLocation":0,"symbol":"OBJC_CLASS_$_MTLTextureDescriptorInternal"},{"value":6691596420,"symbolLocation":0,"symbol":"os_unfair_lock_unlock"},{"value":8553559976},{"value":0},{"value":6157898560},{"value":6157898608},{"value":6157898496},{"value":0},{"value":255},{"value":255},{"value":255},{"value":40},{"value":0},{"value":16843010}],"flavor":"ARM_THREAD_STATE64","lr":{"value":4309744028},"cpsr":{"value":1610616832},"fp":{"value":6157898448},"sp":{"value":6157897696},"esr":{"value":2449473542,"description":"(Data Abort) byte read Translation fault"},"pc":{"value":4309744032,"matchesCrashFrame":1},"far":{"value":48}},"queue":"com.apple.main-thread","frames":[{"imageOffset":784800,"symbol":"DrawMesh","symbolLocation":84,"imageIndex":0},{"imageOffset":784796,"symbol":"DrawMesh","symbolLocation":80,"imageIndex":0},{"imageOffset":818632,"symbol":"DrawModelEx","symbolLocation":1228,"imageIndex":0},{"imageOffset":817392,"symbol":"DrawModel","symbolLocation":92,"imageIndex":0},{"imageOffset":109524,"sourceLine":4107,"sourceFile":"bvhview.c","symbol":"ApplicationUpdate","imageIndex":0,"symbolLocation":5140},{"imageOffset":94528,"sourceLine":4470,"sourceFile":"bvhview.c","symbol":"main","imageIndex":0,"symbolLocation":960},{"imageOffset":27544,"symbol":"start","symbolLocation":6076,"imageIndex":4}]},{"id":2191915,"frames":[{"imageOffset":7020,"symbol":"start_wqthread","symbolLocation":0,"imageIndex":7}],"threadState":{"x":[{"value":6159052800},{"value":3335},{"value":6158516224},{"value":6159051648},{"value":5193730},{"value":1},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6159051520},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6691351404},"far":{"value":0}}},{"id":2191916,"frames":[{"imageOffset":7020,"symbol":"start_wqthread","symbolLocation":0,"imageIndex":7}],"threadState":{"x":[{"value":6158479360},{"value":8707},{"value":6157942784},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6158479360},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6691351404},"far":{"value":0}}},{"id":2191924,"frames":[{"imageOffset":7020,"symbol":"start_wqthread","symbolLocation":0,"imageIndex":7}],"threadState":{"x":[{"value":6159626240},{"value":46595},{"value":6159089664},{"value":6159625088},{"value":5193730},{"value":2},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6159624896},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6691351404},"far":{"value":0}}},{"id":2191928,"name":"com.apple.NSEventThread","threadState":{"x":[{"value":268451845},{"value":21592279046},{"value":8589934592,"symbolLocation":48,"symbol":"_OBJC_CLASS_RO_$_SADeviceCarDNDHintContext"},{"value":112163070935040},{"value":0},{"value":112163070935040},{"value":2},{"value":4294967295},{"value":0},{"value":17179869184},{"value":0},{"value":2},{"value":0},{"value":0},{"value":26115},{"value":0},{"value":18446744073709551569},{"value":8553553000},{"value":0},{"value":4294967295},{"value":2},{"value":112163070935040},{"value":0},{"value":112163070935040},{"value":6160195720},{"value":8589934592,"symbolLocation":48,"symbol":"_OBJC_CLASS_RO_$_SADeviceCarDNDHintContext"},{"value":21592279046},{"value":18446744073709550527},{"value":4412409862}],"flavor":"ARM_THREAD_STATE64","lr":{"value":6691177376},"cpsr":{"value":4096},"fp":{"value":6160195568},"sp":{"value":6160195488},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6691101748},"far":{"value":0}},"frames":[{"imageOffset":3124,"symbol":"mach_msg2_trap","symbolLocation":8,"imageIndex":8},{"imageOffset":78752,"symbol":"mach_msg2_internal","symbolLocation":76,"imageIndex":8},{"imageOffset":38756,"symbol":"mach_msg_overwrite","symbolLocation":484,"imageIndex":8},{"imageOffset":4008,"symbol":"mach_msg","symbolLocation":24,"imageIndex":8},{"imageOffset":511164,"symbol":"__CFRunLoopServiceMachPort","symbolLocation":160,"imageIndex":9},{"imageOffset":505304,"symbol":"__CFRunLoopRun","symbolLocation":1208,"imageIndex":9},{"imageOffset":502424,"symbol":"CFRunLoopRunSpecific","symbolLocation":572,"imageIndex":9},{"imageOffset":1435532,"symbol":"_NSEventThread","symbolLocation":140,"imageIndex":10},{"imageOffset":27660,"symbol":"_pthread_start","symbolLocation":136,"imageIndex":7},{"imageOffset":7040,"symbol":"thread_start","symbolLocation":8,"imageIndex":7}]},{"id":2191930,"frames":[{"imageOffset":7020,"symbol":"start_wqthread","symbolLocation":0,"imageIndex":7}],"threadState":{"x":[{"value":6160773120},{"value":0},{"value":6160236544},{"value":0},{"value":278532},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6160773120},"esr":{"value":0,"description":" Address size fault"},"pc":{"value":6691351404},"far":{"value":0}}}],
  "usedImages" : [
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4308959232,
    "size" : 1130496,
    "uuid" : "b3122b4a-d1f9-3b2b-8244-b53945d04198",
    "path" : "*\/bvhview",
    "name" : "bvhview"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 4319019008,
    "size" : 49152,
    "uuid" : "a3faee04-0f8b-3428-9497-560c97eca6fb",
    "path" : "\/usr\/lib\/libobjc-trampolines.dylib",
    "name" : "libobjc-trampolines.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 4635901952,
    "CFBundleShortVersionString" : "329.2",
    "CFBundleIdentifier" : "com.apple.AGXMetalG13X",
    "size" : 6914048,
    "uuid" : "6b497f3b-6583-398c-9d05-5f30a1c1bae5",
    "path" : "\/System\/Library\/Extensions\/AGXMetalG13X.bundle\/Contents\/MacOS\/AGXMetalG13X",
    "name" : "AGXMetalG13X",
    "CFBundleVersion" : "329.2"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 4319444992,
    "CFBundleShortVersionString" : "1.0",
    "CFBundleIdentifier" : "com.apple.AppleMetalOpenGLRenderer",
    "size" : 425984,
    "uuid" : "28cfca54-b985-318a-a54a-7709dcd5f39e",
    "path" : "\/System\/Library\/Extensions\/AppleMetalOpenGLRenderer.bundle\/Contents\/MacOS\/AppleMetalOpenGLRenderer",
    "name" : "AppleMetalOpenGLRenderer",
    "CFBundleVersion" : "1"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6687539200,
    "size" : 636280,
    "uuid" : "3247e185-ced2-36ff-9e29-47a77c23e004",
    "path" : "\/usr\/lib\/dyld",
    "name" : "dyld"
  },
  {
    "size" : 0,
    "source" : "A",
    "base" : 0,
    "uuid" : "00000000-0000-0000-0000-000000000000"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6691594240,
    "size" : 32268,
    "uuid" : "fd19a599-8750-31f9-924f-c2810c938371",
    "path" : "\/usr\/lib\/system\/libsystem_platform.dylib",
    "name" : "libsystem_platform.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6691344384,
    "size" : 51784,
    "uuid" : "d6494ba9-171e-39fc-b1aa-28ecf87975d1",
    "path" : "\/usr\/lib\/system\/libsystem_pthread.dylib",
    "name" : "libsystem_pthread.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6691098624,
    "size" : 243284,
    "uuid" : "6e4a96ad-04b8-3e8a-b91d-087e62306246",
    "path" : "\/usr\/lib\/system\/libsystem_kernel.dylib",
    "name" : "libsystem_kernel.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6691823616,
    "CFBundleShortVersionString" : "6.9",
    "CFBundleIdentifier" : "com.apple.CoreFoundation",
    "size" : 5500928,
    "uuid" : "8d45baee-6cc0-3b89-93fd-ea1c8e15c6d7",
    "path" : "\/System\/Library\/Frameworks\/CoreFoundation.framework\/Versions\/A\/CoreFoundation",
    "name" : "CoreFoundation",
    "CFBundleVersion" : "3603"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6758297600,
    "CFBundleShortVersionString" : "6.9",
    "CFBundleIdentifier" : "com.apple.AppKit",
    "size" : 21564992,
    "uuid" : "860c164c-d04c-30ff-8c6f-e672b74caf11",
    "path" : "\/System\/Library\/Frameworks\/AppKit.framework\/Versions\/C\/AppKit",
    "name" : "AppKit",
    "CFBundleVersion" : "2575.70.52"
  }
],
  "sharedCache" : {
  "base" : 6686703616,
  "size" : 5040898048,
  "uuid" : "032c7bce-a479-35b8-97bc-ce7f8f80ccab"
},
  "legacyInfo" : {
  "threadTriggered" : {
    "queue" : "com.apple.main-thread"
  }
},
  "logWritingSignature" : "3ebb714aebae90ca0198746d56decacc59a3e31a",
  "trialInfo" : {
  "rollouts" : [
    {
      "rolloutId" : "5ffde50ce2aacd000d47a95f",
      "factorPackIds" : {

      },
      "deploymentId" : 240000500
    },
    {
      "rolloutId" : "60186475825c62000ccf5450",
      "factorPackIds" : {

      },
      "deploymentId" : 240000083
    }
  ],
  "experiments" : [
    {
      "treatmentId" : "f18344bb-554f-48ae-8449-e108a8813a55",
      "experimentId" : "6685b5584477001000e8c6c9",
      "deploymentId" : 400000009
    }
  ]
}
}

Model: MacBookPro18,1, BootROM 11881.140.96, proc 10:8:2 processors, 16 GB, SMC 
Graphics: Apple M1 Pro, Apple M1 Pro, Built-In
Display: Color LCD, 3456 x 2234 Retina, Main, MirrorOff, Online
Memory Module: LPDDR5, Samsung
AirPort: spairport_wireless_card_type_wifi (0x14E4, 0x4387), wl0: Mar 23 2025 19:56:28 version 20.130.17.0.8.7.197 FWID 01-764e34b7
IO80211_driverkit-1485.7 "IO80211_driverkit-1485.7" Jul 15 2025 20:46:41
AirPort: 
Bluetooth: Version (null), 0 services, 0 devices, 0 incoming serial ports
Network Service: Wi-Fi, AirPort, en0
Network Service: Tailscale 3, VPN (io.tailscale.ipn.macsys), utun4
USB Device: USB31Bus
USB Device: USB31Bus
USB Device: USB31Bus
Thunderbolt Bus: MacBook Pro, Apple Inc.
Thunderbolt Bus: MacBook Pro, Apple Inc.
Thunderbolt Bus: MacBook Pro, Apple Inc.
```